### PR TITLE
Call two seq() explicitly as Rcpp::seq()

### DIFF
--- a/src/_g_mcsMAT2.cpp
+++ b/src/_g_mcsMAT2.cpp
@@ -250,13 +250,13 @@ SEXP mcsMAT0_ ( SEXP XX_, SEXP mcs0idx_){
   case INTSXP  : 
   case REALSXP : {
     NumericMatrix X(as<NumericMatrix>(XX_));
-    if (zz_.isNULL())  mcs0idx = seq(0, X.ncol()-1);
+    if (zz_.isNULL())  mcs0idx = Rcpp::seq(0, X.ncol()-1);
     else mcs0idx = mcs0idx_;
     return do_mcs_dense ( X, mcs0idx ); 
   }
   case S4SXP   : {                               
     MSpMat X(as<MSpMat>(XX_));
-    if (zz_.isNULL()) mcs0idx = seq(0, X.cols()-1);
+    if (zz_.isNULL()) mcs0idx = Rcpp::seq(0, X.cols()-1);
     else mcs0idx = mcs0idx_;
     return do_mcs_sparse( X, mcs0idx );
   } 


### PR DESCRIPTION
Dear Søren, dear gR* team,

Eigen 3.4.0 was released earlier in the year, and I have been asked to update RcppEigen to it. As documented in this issue at its GitHub repo, there are about 10 packages that built at CRAN under the previous release, but not with the Eigen 3.4.0 changes in the release candidate package -- which can be installed via

    install.packages("RcppEigen", repo="https://RcppCore.github.io/drat")

For `gRbase`, the change is fairly simple. Apparently Eigen 3.4.0 confuses another `seq()` declaration so we (in just two places) need `Rcpp::seq()`.  With that simple changes in this PR, the package installs for me.

It would be helpful for RcppEigen if you could apply the patch and release an updated version so that RcppEigen could be upgraded to a version with Eigen 3.4.0.

Let me know if you have any question, and please do not hesitate to reply and ask.

Cheers, Dirk (who looks after RcppEigen as a care-taker...)