### PR TITLE
Fix: use minimal_triang() in mpd.default() to ensure correct decomposition (#12)

### DIFF
--- a/R/igraph_mpd.R
+++ b/R/igraph_mpd.R
@@ -80,7 +80,7 @@ mpd <- function(object, tobject=minimal_triang(object), details=0) {
 
 #' @export
 #' @rdname graph-mpd
-mpd.default <- function(object, tobject=triangulate(object), details=0){
+mpd.default <- function(object, tobject=minimal_triang(object), details=0){
 
     graph_class <- c("igraph", "matrix", "dgCMatrix")
     chk <- inherits(object, graph_class, which=TRUE)
@@ -166,6 +166,5 @@ mpdMAT <- function(amat, tamat=minimal_triangMAT(amat), details=0){
       return(MPDTree)
     }
 }
-
 
 

--- a/R/igraph_mpd.R
+++ b/R/igraph_mpd.R
@@ -168,3 +168,4 @@ mpdMAT <- function(amat, tamat=minimal_triangMAT(amat), details=0){
 }
 
 
+


### PR DESCRIPTION
Hi Søren,

I have implemented the fix discussed in Issue #12.

The current mpd.default() uses triangulate() which can add redundant chords, potentially leading to incorrect prime subgraph merges. By switching to minimal_triang(), we ensure the decomposition remains mathematically sound for non-chordal graphs.

This change has been tested against the example provided in #12 and yields the correct decomposition.