### PR TITLE
Fix: use minimal_triang() in mpd.default() to ensure correct decomposition

### DIFF
--- a/R/igraph_mpd.R
+++ b/R/igraph_mpd.R
@@ -80,7 +80,7 @@ mpd <- function(object, tobject=minimal_triang(object), details=0) {
 
 #' @export
 #' @rdname graph-mpd
-mpd.default <- function(object, tobject=triangulate(object), details=0){
+mpd.default <- function(object, tobject=minimal_triang(object), details=0){
 
     graph_class <- c("igraph", "matrix", "dgCMatrix")
     chk <- inherits(object, graph_class, which=TRUE)


### PR DESCRIPTION
Hi Søren,

I have implemented the fix discussed in Issue https://github.com/hojsgaard/gRbase/issues/12.

The current mpd.default() uses triangulate() which can add redundant chords, potentially leading to incorrect prime subgraph merges. By switching to minimal_triang(), we ensure the decomposition remains mathematically sound for non-chordal graphs.

This change has been tested against the example provided in https://github.com/hojsgaard/gRbase/issues/12 and yields the correct decomposition.